### PR TITLE
Remove refs from dep arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,11 @@ export const useTyping = ({
 
   useEffect(() => {
     setCharIndex(charIndexRef.current)
-  }, [charIndexRef.current])
+  }, [])
 
   useEffect(() => {
     setPhraseIndex(phraseIndexRef.current)
-  }, [phraseIndexRef.current])
+  }, [])
 
   const keystroke = async () => {
     let nextDelay = speed


### PR DESCRIPTION
This is a great hook @jagonzalr

Thanks for sharing it! For your benefit, I wanted to point out that refs operate outside of the react render mechanism, so the hook throws an error:

`React Hook useEffect has an unnecessary dependency: 'phraseIndexRef.current'. Either exclude it or remove the dependency array. Mutable values like 'phraseIndexRef.current' aren't valid dependencies because mutating them doesn't re-render the component.`

Since the purpose is to run the effect one time to initialize phraseIndex, you can just delete the